### PR TITLE
Use utcnow instead of now for dates as ckan internal dates should always be utc based

### DIFF
--- a/ckanext/report/model.py
+++ b/ckanext/report/model.py
@@ -80,7 +80,7 @@ class DataCache(object):
             return (None, None)
 
         if max_age:
-            age = datetime.datetime.now() - item.created
+            age = datetime.datetime.utcnow() - item.created
             if age > max_age:
                 log.debug('Cache not returned - it is older than requested %s/%s %r > %r',
                           object_id, key, age, max_age)
@@ -125,7 +125,7 @@ class DataCache(object):
             model.Session.add(item)
         else:
             item.value = value
-        item.created = datetime.datetime.now()
+        item.created = datetime.datetime.utcnow()
 
         log.debug('Cache save: %s/%s', object_id, key)
         model.Session.flush()

--- a/ckanext/report/model.py
+++ b/ckanext/report/model.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import json
 
-import pytz
 from sqlalchemy import types, Table, Column, Index, MetaData
 from sqlalchemy.orm import mapper
 
@@ -24,7 +23,7 @@ data_cache_table = Table(
     Column('object_id', types.UnicodeText, index=True),
     Column('key', types.UnicodeText, nullable=False),
     Column('value', types.UnicodeText),
-    Column('created', types.DateTime, default=datetime.datetime.now(tzinfo=pytz.utc)),
+    Column('created', types.DateTime, default=datetime.datetime.utcnow),
 )
 Index('idx_data_cache_object_id_key', data_cache_table.c.object_id,
       data_cache_table.c.key)

--- a/ckanext/report/model.py
+++ b/ckanext/report/model.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import json
 
+import pytz
 from sqlalchemy import types, Table, Column, Index, MetaData
 from sqlalchemy.orm import mapper
 
@@ -23,7 +24,7 @@ data_cache_table = Table(
     Column('object_id', types.UnicodeText, index=True),
     Column('key', types.UnicodeText, nullable=False),
     Column('value', types.UnicodeText),
-    Column('created', types.DateTime, default=datetime.datetime.now),
+    Column('created', types.DateTime, default=datetime.datetime.now(tzinfo=pytz.utc)),
 )
 Index('idx_data_cache_object_id_key', data_cache_table.c.object_id,
       data_cache_table.c.key)


### PR DESCRIPTION
python takes server timezone but when saved does not changed back to utc and causes all sorts of oddness. comments inside ckan core state that all datetimes should be utc timezone and best way to get that is with utcnow
